### PR TITLE
Refactoring various components so _post_configure is not necessary.

### DIFF
--- a/openmdao/components/add_subtract_comp.py
+++ b/openmdao/components/add_subtract_comp.py
@@ -31,8 +31,13 @@ class AddSubtractComp(ExplicitComponent):
 
     Attributes
     ----------
-    _add_systems : list
+    _equations : list
         List of equation systems to be initialized with the system.
+    _has_initial_equation : bool
+        True if the component is instantiated with an equation, else False.
+    _input_names : dict
+        Dictionary of input names and key associated options for inputs so that a given
+        input name can be used in multiple equations.
     """
 
     def __init__(self, output_name=None, input_names=None, vec_size=1, length=1,
@@ -68,11 +73,16 @@ class AddSubtractComp(ExplicitComponent):
         """
         super(AddSubtractComp, self).__init__()
 
-        self._add_systems = []
+        # Add systems is used to store those systems provided upon initialization
+        self._equations = []
+
+        self._has_initial_equation = False
+        self._input_names = {}
 
         if isinstance(output_name, str):
-            self._add_systems.append((output_name, input_names, vec_size, length, val,
-                                      scaling_factors, kwargs))
+            self._has_initial_equation = True
+            self._equations.append((output_name, input_names, vec_size, length, val,
+                                    scaling_factors, kwargs))
         elif isinstance(output_name, collections.Iterable):
             raise NotImplementedError(self.msginfo + ': Declaring multiple addition systems '
                                       'on initiation is not implemented.'
@@ -96,9 +106,17 @@ class AddSubtractComp(ExplicitComponent):
         self.options.declare('complex', types=bool, default=False,
                              desc="Allocate as complex (e.g. for complex-step verification)")
 
+    def setup(self):
+        """
+        Declare inputs, outputs, and derivatives for the add_subtract component.
+        """
+        if self._has_initial_equation:
+            op_name, ip_names, vec_size, length, val, scaling_factors, kwargs = self._equations[0]
+            self.add_equation(op_name, ip_names, vec_size, length, val, append=False, **kwargs)
+
     def add_equation(self, output_name, input_names, vec_size=1, length=1, val=1.0,
                      units=None, res_units=None, desc='', lower=None, upper=None, ref=1.0,
-                     ref0=0.0, res_ref=None, scaling_factors=None):
+                     ref0=0.0, res_ref=None, scaling_factors=None, append=True):
         """
         Add an addition/subtraction relation.
 
@@ -113,7 +131,7 @@ class AddSubtractComp(ExplicitComponent):
             (i.e number of rows, or vector length for a 1D vector)
             Default is 1
         length : int
-            Length of the second dimension of the input and ouptut vectors (i.e. number of columns)
+            Length of the second dimension of the input and output vectors (i.e. number of columns)
             Default is 1 which results in input/output vectors of size (vec_size,)
         scaling_factors : iterable of numeric
             Scaling factors to apply to each input.
@@ -150,12 +168,60 @@ class AddSubtractComp(ExplicitComponent):
         res_ref : float or ndarray
             Scaling parameter. The value in the user-defined res_units of this output's residual
             when the scaled value is 1. Default is 1.
+        append : bool
+            If True, add the given equation to the list.  If False, add the appropriate I/O but
+            do not append the given equation to the internal list.
         """
         kwargs = {'units': units, 'res_units': res_units, 'desc': desc,
                   'lower': lower, 'upper': upper, 'ref': ref, 'ref0': ref0,
                   'res_ref': res_ref}
-        self._add_systems.append((output_name, input_names, vec_size, length, val,
-                                  scaling_factors, kwargs))
+
+        if isinstance(input_names, str):
+            input_names = input_names
+
+        if scaling_factors is None:
+            scaling_factors = np.ones(len(input_names))
+        elif len(scaling_factors) != len(input_names):
+            raise ValueError(self.msginfo + ': Scaling factors list needs to be same length '
+                             'as input names')
+
+        if length == 1:
+            shape = (vec_size,)
+        else:
+            shape = (vec_size, length)
+
+        super(AddSubtractComp, self).add_output(output_name, val, shape=shape, **kwargs)
+
+        if append:
+            self._equations.append((output_name, input_names, vec_size, length, val,
+                                    scaling_factors, kwargs))
+
+        for i, input_name in enumerate(input_names):
+            if input_name not in self._input_names:
+                self.add_input(input_name, shape=shape, units=units,
+                               desc=desc + '_inp_' + input_name)
+                sf = scaling_factors[i]
+                self.declare_partials([output_name], [input_name],
+                                      val=sf * sp.eye(vec_size * length, format='csc'))
+                self._input_names[input_name] = {'vec_size': vec_size, 'length': length,
+                                                 'units': units}
+            else:
+                # Verify that the input is consistent with that added for a previous equation
+                prev_vec_size = self._input_names[input_name]['vec_size']
+                prev_length = self._input_names[input_name]['length']
+                prev_units = self._input_names[input_name]['units']
+                if vec_size != prev_vec_size:
+                    raise ValueError(self.msginfo + f': Input {input_name} was added in a previous '
+                                                    f'equation but had a different vec_size '
+                                                    f'({prev_vec_size} vs. {vec_size}.')
+                if length != prev_length:
+                    raise ValueError(self.msginfo + f': Input {input_name} was added in a previous '
+                                                    f'equation but had a different length '
+                                                    f'({prev_length} vs. {length}.')
+                if units != prev_units:
+                    raise ValueError(self.msginfo + f': Input {input_name} was added in a previous '
+                                                    f'equation but had different units '
+                                                    f'({prev_units} vs. {units}.')
 
     def add_output(self):
         """
@@ -163,45 +229,6 @@ class AddSubtractComp(ExplicitComponent):
         """
         raise NotImplementedError(self.msginfo + ': Use add_equation method, not add_output '
                                   'method to create an addition/subtraction relation')
-
-    def _post_configure(self):
-        """
-        Set up the addition/subtraction system at run time.
-        """
-        # set static mode to False because we are doing things that would normally be done in setup
-        self._static_mode = False
-
-        for (output_name, input_names, vec_size, length, val,
-             scaling_factors, kwargs) in self._add_systems:
-            if isinstance(input_names, str):
-                input_names = [input_names]
-
-            units = kwargs['units']
-            desc = kwargs['desc']
-
-            if scaling_factors is None:
-                scaling_factors = np.ones(len(input_names))
-
-            if len(scaling_factors) != len(input_names):
-                raise ValueError(self.msginfo + ': Scaling factors list needs to be same length '
-                                 'as input names')
-            if length == 1:
-                shape = (vec_size,)
-            else:
-                shape = (vec_size, length)
-
-            super(AddSubtractComp, self).add_output(output_name, val, shape=shape, **kwargs)
-
-            for i, input_name in enumerate(input_names):
-                self.add_input(input_name, shape=shape, units=units,
-                               desc=desc + '_inp_' + input_name)
-                sf = scaling_factors[i]
-                self.declare_partials([output_name], [input_name],
-                                      val=sf * sp.eye(vec_size * length, format='csc'))
-
-        self._static_mode = True
-
-        super(AddSubtractComp, self)._post_configure()
 
     def compute(self, inputs, outputs):
         """
@@ -216,7 +243,7 @@ class AddSubtractComp(ExplicitComponent):
         """
         complexify = self.options['complex']
         for (output_name, input_names, vec_size, length, val, scaling_factors,
-             kwargs) in self._add_systems:
+             kwargs) in self._equations:
             if isinstance(input_names, str):
                 input_names = [input_names]
 

--- a/openmdao/components/add_subtract_comp.py
+++ b/openmdao/components/add_subtract_comp.py
@@ -79,7 +79,8 @@ class AddSubtractComp(ExplicitComponent):
         self._input_names = {}
 
         if isinstance(output_name, str):
-            self.add_equation(output_name, input_names, vec_size, length, val, scaling_factors, kwargs)
+            self.add_equation(output_name, input_names, vec_size, length, val, scaling_factors,
+                              kwargs)
         elif isinstance(output_name, collections.Iterable):
             raise NotImplementedError(self.msginfo + ': Declaring multiple addition systems '
                                       'on initiation is not implemented.'

--- a/openmdao/components/add_subtract_comp.py
+++ b/openmdao/components/add_subtract_comp.py
@@ -33,8 +33,6 @@ class AddSubtractComp(ExplicitComponent):
     ----------
     _equations : list
         List of equation systems to be initialized with the system.
-    _has_initial_equation : bool
-        True if the component is instantiated with an equation, else False.
     _input_names : dict
         Dictionary of input names and key associated options for inputs so that a given
         input name can be used in multiple equations.
@@ -76,13 +74,12 @@ class AddSubtractComp(ExplicitComponent):
         # Add systems is used to store those systems provided upon initialization
         self._equations = []
 
-        self._has_initial_equation = False
+        # Input names will store the names of inputs and their key properties which must be
+        # the same across all equations in which they are used.
         self._input_names = {}
 
         if isinstance(output_name, str):
-            self._has_initial_equation = True
-            self._equations.append((output_name, input_names, vec_size, length, val,
-                                    scaling_factors, kwargs))
+            self.add_equation(output_name, input_names, vec_size, length, val, scaling_factors, kwargs)
         elif isinstance(output_name, collections.Iterable):
             raise NotImplementedError(self.msginfo + ': Declaring multiple addition systems '
                                       'on initiation is not implemented.'
@@ -105,14 +102,6 @@ class AddSubtractComp(ExplicitComponent):
         """
         self.options.declare('complex', types=bool, default=False,
                              desc="Allocate as complex (e.g. for complex-step verification)")
-
-    def setup(self):
-        """
-        Declare inputs, outputs, and derivatives for the add_subtract component.
-        """
-        if self._has_initial_equation:
-            op_name, ip_names, vec_size, length, val, scaling_factors, kwargs = self._equations[0]
-            self.add_equation(op_name, ip_names, vec_size, length, val, append=False, **kwargs)
 
     def add_equation(self, output_name, input_names, vec_size=1, length=1, val=1.0,
                      units=None, res_units=None, desc='', lower=None, upper=None, ref=1.0,

--- a/openmdao/components/mux_comp.py
+++ b/openmdao/components/mux_comp.py
@@ -64,63 +64,53 @@ class MuxComp(ExplicitComponent):
         """
         self._vars[name] = {'val': val, 'shape': shape, 'units': units, 'desc': desc, 'axis': axis}
 
-    def _post_configure(self):
-        """
-        Declare inputs, outputs, and derivatives for the demux component.
-        """
-        # set static mode to False because we are doing things that would normally be done in setup
-        self._static_mode = False
-
         opts = self.options
         vec_size = opts['vec_size']
 
-        for var, options in self._vars.items():
-            kwgs = dict(options)
-            in_shape = np.asarray(options['val']).shape \
-                if options['shape'] is None else options['shape']
-            in_size = np.prod(in_shape)
-            out_shape = list(in_shape)
-            out_shape.insert(options['axis'], vec_size)
-            kwgs.pop('shape')
-            ax = kwgs.pop('axis')
+        options = self._vars[name]
 
-            in_dimension = len(in_shape)
+        kwgs = dict(options)
+        in_shape = np.asarray(options['val']).shape \
+            if options['shape'] is None else options['shape']
+        in_size = np.prod(in_shape)
+        out_shape = list(in_shape)
+        out_shape.insert(options['axis'], vec_size)
+        kwgs.pop('shape')
+        ax = kwgs.pop('axis')
 
-            if ax > in_dimension:
-                raise ValueError('{3}: Cannot mux a {0}D inputs for {2} along axis greater '
-                                 'than {0} ({1})'.format(in_dimension, ax, var, self.msginfo))
+        in_dimension = len(in_shape)
 
-            self.add_output(name=var,
-                            val=options['val'],
-                            shape=out_shape,
-                            units=options['units'],
-                            desc=options['desc'])
+        if ax > in_dimension:
+            raise ValueError('{3}: Cannot mux a {0}D inputs for {2} along axis greater '
+                             'than {0} ({1})'.format(in_dimension, ax, name, self.msginfo))
 
-            self._input_names[var] = []
+        self.add_output(name=name,
+                        val=options['val'],
+                        shape=out_shape,
+                        units=options['units'],
+                        desc=options['desc'])
 
-            for i in range(vec_size):
-                in_name = '{0}_{1}'.format(var, i)
-                self._input_names[var].append(in_name)
+        self._input_names[name] = []
 
-                self.add_input(name=in_name, shape=in_shape, **kwgs)
+        for i in range(vec_size):
+            in_name = '{0}_{1}'.format(name, i)
+            self._input_names[name].append(in_name)
 
-                in_templates = [np.zeros(in_shape, dtype=int) for _ in range(vec_size)]
+            self.add_input(name=in_name, shape=in_shape, **kwgs)
 
-                rs = []
-                cs = []
+            in_templates = [np.zeros(in_shape, dtype=int) for _ in range(vec_size)]
 
-                for j in range(in_size):
-                    in_templates[i].flat[:] = 0
-                    in_templates[i].flat[j] = 1
-                    temp_out = np.stack(in_templates, axis=ax)
-                    cs.append(j)
-                    rs.append(int(np.nonzero(temp_out.ravel())[0]))
+            rs = []
+            cs = []
 
-                self.declare_partials(of=var, wrt=in_name, rows=rs, cols=cs, val=1.0)
+            for j in range(in_size):
+                in_templates[i].flat[:] = 0
+                in_templates[i].flat[j] = 1
+                temp_out = np.stack(in_templates, axis=ax)
+                cs.append(j)
+                rs.append(int(np.nonzero(temp_out.ravel())[0]))
 
-        self._static_mode = True
-
-        super(MuxComp, self)._post_configure()
+            self.declare_partials(of=name, wrt=in_name, rows=rs, cols=cs, val=1.0)
 
     def compute(self, inputs, outputs):
         """

--- a/openmdao/components/tests/test_add_subtract_comp.py
+++ b/openmdao/components/tests/test_add_subtract_comp.py
@@ -265,7 +265,7 @@ class TestAddSubtractUnits(unittest.TestCase):
 
 class TestWrongScalingFactorCount(unittest.TestCase):
 
-    def setUp(self):
+    def test_for_exception(self):
         self.nn = 5
         self.p = om.Problem()
 
@@ -280,15 +280,15 @@ class TestWrongScalingFactorCount(unittest.TestCase):
 
         adder=self.p.model.add_subsystem(name='add_subtract_comp',
                                    subsys=om.AddSubtractComp())
-        adder.add_equation('adder_output',['input_a','input_b','input_c'],vec_size=self.nn,length=3,scaling_factors=[1,-1])
 
-        self.p.model.connect('a', 'add_subtract_comp.input_a')
-        self.p.model.connect('b', 'add_subtract_comp.input_b')
-        self.p.model.connect('c', 'add_subtract_comp.input_c')
+        with self.assertRaises(ValueError) as err:
+            adder.add_equation('adder_output', ['input_a', 'input_b', 'input_c'], vec_size=self.nn,
+                               length=3, scaling_factors=[1, -1])
 
+        expected_msg = 'AddSubtractComp (add_subtract_comp): Scaling factors list needs to be ' \
+                       'same length as input names'
 
-    def test_for_exception(self):
-        self.assertRaises(ValueError,self.p.setup)
+        self.assertEqual(str(err.exception), expected_msg)
 
 
 class TestFeature(unittest.TestCase):

--- a/openmdao/components/tests/test_demux_comp.py
+++ b/openmdao/components/tests/test_demux_comp.py
@@ -20,12 +20,8 @@ class TestDemuxCompOptions(unittest.TestCase):
 
         demux_comp = p.model.add_subsystem(name='demux_comp', subsys=om.DemuxComp(vec_size=nn))
 
-        demux_comp.add_var('a', shape=(nn,), axis=1)
-
-        p.model.connect('a', 'demux_comp.a')
-
         with self.assertRaises(RuntimeError) as ctx:
-            p.setup()
+            demux_comp.add_var('a', shape=(nn,), axis=1)
         self.assertEqual(str(ctx.exception),
                          "DemuxComp (demux_comp): Invalid axis (1) for variable 'a' of shape (10,)")
 
@@ -42,14 +38,8 @@ class TestDemuxCompOptions(unittest.TestCase):
 
         demux_comp = p.model.add_subsystem(name='demux_comp', subsys=om.DemuxComp(vec_size=nn))
 
-        demux_comp.add_var('a', shape=(nn, 7), axis=1)
-        demux_comp.add_var('b', shape=(3, nn), axis=1)
-
-        p.model.connect('a', 'demux_comp.a')
-        p.model.connect('b', 'demux_comp.b')
-
         with self.assertRaises(RuntimeError) as ctx:
-            p.setup()
+            demux_comp.add_var('a', shape=(nn, 7), axis=1)
         self.assertEqual(str(ctx.exception),
                          "DemuxComp (demux_comp): Variable 'a' cannot be demuxed along axis 1. Axis size is "
                          "7 but vec_size is 10.")

--- a/openmdao/components/tests/test_mux_comp.py
+++ b/openmdao/components/tests/test_mux_comp.py
@@ -21,13 +21,8 @@ class TestMuxCompOptions(unittest.TestCase):
 
         mux_comp = p.model.add_subsystem(name='mux_comp', subsys=om.MuxComp(vec_size=nn))
 
-        mux_comp.add_var('a', shape=(1,), axis=2)
-
-        for i in range(nn):
-            p.model.connect('a_{0}'.format(i), 'mux_comp.a_{0}'.format(i))
-
         with self.assertRaises(ValueError) as ctx:
-            p.setup()
+            mux_comp.add_var('a', shape=(1,), axis=2)
         self.assertEqual(str(ctx.exception),
                          'MuxComp (mux_comp): Cannot mux a 1D inputs for a along axis greater than 1 (2)')
 
@@ -51,16 +46,12 @@ class TestMuxCompOptions(unittest.TestCase):
         mux_comp = p.model.add_subsystem(name='mux_comp', subsys=om.MuxComp(vec_size=nn))
 
         mux_comp.add_var('a', shape=(a_size,), axis=0)
-        mux_comp.add_var('b', shape=(b_size,), axis=2)
-
-        for i in range(nn):
-            p.model.connect('a_{0}'.format(i), 'mux_comp.a_{0}'.format(i))
-            p.model.connect('b_{0}'.format(i), 'mux_comp.b_{0}'.format(i))
 
         with self.assertRaises(ValueError) as ctx:
-            p.setup()
+            mux_comp.add_var('b', shape=(b_size,), axis=2)
         self.assertEqual(str(ctx.exception),
-                         'MuxComp (mux_comp): Cannot mux a 1D inputs for b along axis greater than 1 (2)')
+                         'MuxComp (mux_comp): Cannot mux a 1D inputs for b along axis greater '
+                         'than 1 (2)')
 
 
 class TestMuxCompScalar(unittest.TestCase):

--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -56,7 +56,6 @@ class IndepVarComp(ExplicitComponent):
             self._indep.append((name, val, kwargs))
             super(IndepVarComp, self).add_output(name, val, **kwargs)
 
-
         elif name is None:
             pass
 
@@ -94,8 +93,6 @@ class IndepVarComp(ExplicitComponent):
                                "afterwards.".format(self.msginfo))
 
         # self._static_mode = True
-
-
         # super(IndepVarComp, self)._post_configure()
 
     def add_output(self, name, val=1.0, shape=None, units=None, res_units=None, desc='',


### PR DESCRIPTION
### Summary

Removes need for _post_configure call in AddSubtractComp.
Inputs can be used in multiple equations, but exceptions are raised if shapes or units differ for those inputs across different equations.

### Related Issues

N/A

### Backwards incompatibilities

None

### New Dependencies

None
